### PR TITLE
Added time constraints for Parquet file generation and row-group-size flush policy.

### DIFF
--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -37,7 +37,6 @@
     <hamcrest.version>2.1</hamcrest.version>
     <jackson.version>2.10.2</jackson.version>
     <joda.version>2.10.5</joda.version>
-    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <pubsub.version>v1-rev20191111-1.30.3</pubsub.version>
@@ -65,16 +64,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
+  <parent>
 		<groupId>org.openmrs.analytics</groupId>
 		<artifactId>fhir</artifactId>
 		<version>0.1.0-SNAPSHOT</version>
@@ -120,6 +120,12 @@
 		<groupId>com.beust</groupId>
 		<artifactId>jcommander</artifactId>
 	</dependency>
+  <dependency>
+    <groupId>com.google.jimfs</groupId>
+    <artifactId>jimfs</artifactId>
+    <version>1.1</version>
+    <scope>test</scope>
+  </dependency>
   </dependencies>
 
 </project>

--- a/common/src/main/java/org/openmrs/analytics/BaseArgs.java
+++ b/common/src/main/java/org/openmrs/analytics/BaseArgs.java
@@ -37,4 +37,14 @@ public class BaseArgs {
 	
 	@Parameter(names = { "--fileParquetPath" }, description = "The base path for output Parquet files")
 	public String fileParquetPath = "/tmp/";
+	
+	@Parameter(names = { "--secondsToFlushParquetFiles" }, description = "The number of seconds after which all Parquet "
+	        + "writers with non-empty content are flushed to files; use 0 to disable.")
+	public int secondsToFlushParquetFiles = 3600;
+	
+	@Parameter(names = { "--rowGroupSizeForParquetFiles" }, description = "The approximate size (bytes) of "
+	        + "the row-groups in Parquet files. When this size is reached, the content is flushed to disk. "
+	        + "This won't be triggered if there are less than 100 records. Use 0 to fall back to the "
+	        + "default row-group size.")
+	public int rowGroupSizeForParquetFiles = 0;
 }

--- a/common/src/main/java/org/openmrs/analytics/ParquetUtil.java
+++ b/common/src/main/java/org/openmrs/analytics/ParquetUtil.java
@@ -162,7 +162,7 @@ public class ParquetUtil {
 		return bestFilePath;
 	}
 	
-	synchronized private void craeteWriter(String resourceType) throws IOException {
+	synchronized private void createWriter(String resourceType) throws IOException {
 		// TODO: Find a way to convince Hadoop file operations to use `fileSystem` (needed for testing).
 		AvroParquetWriter.Builder<GenericRecord> builder = AvroParquetWriter.builder(bestOutputFile(resourceType));
 		// TODO: Adjust other parquet file parameters for our needs or make them configurable.
@@ -185,7 +185,7 @@ public class ParquetUtil {
 		Preconditions.checkNotNull(resource.fhirType());
 		String resourceType = resource.fhirType();
 		if (!writerMap.containsKey(resourceType)) {
-			craeteWriter(resourceType);
+			createWriter(resourceType);
 		}
 		final ParquetWriter<GenericRecord> parquetWriter = writerMap.get(resourceType);
 		parquetWriter.write(this.convertToAvro(resource));
@@ -195,7 +195,7 @@ public class ParquetUtil {
 		ParquetWriter<GenericRecord> writer = writerMap.get(resourceType);
 		if (writer != null && writer.getDataSize() > 0) {
 			writer.close();
-			craeteWriter(resourceType);
+			createWriter(resourceType);
 		}
 	}
 	

--- a/common/src/main/java/org/openmrs/analytics/ParquetUtil.java
+++ b/common/src/main/java/org/openmrs/analytics/ParquetUtil.java
@@ -15,13 +15,24 @@
 package org.openmrs.analytics;
 
 import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import ca.uhn.fhir.context.FhirContext;
 import com.cerner.bunsen.avro.AvroConverter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.avro.Conversions.DecimalConversion;
 import org.apache.avro.Schema;
@@ -41,13 +52,19 @@ public class ParquetUtil {
 	
 	private static final Logger log = LoggerFactory.getLogger(ParquetUtil.class);
 	
+	private static final Pattern OUTPUT_PATTERN = Pattern.compile(".*output-streaming-([\\p{Digit}]{5}+)");
+	
 	private final FhirContext fhirContext;
 	
 	private final Map<String, AvroConverter> converterMap;
 	
 	private final Map<String, ParquetWriter<GenericRecord>> writerMap;
 	
-	private String parquetFilePath;
+	private final int rowGroupSize;
+	
+	private final String parquetFilePath;
+	
+	private final FileSystem fileSystem;
 	
 	/**
 	 * This is to fix the logical type conversions for BigDecimal. This should be called once before any
@@ -65,11 +82,51 @@ public class ParquetUtil {
 		return this.parquetFilePath;
 	}
 	
-	ParquetUtil(String parquetFilePath) {
+	/**
+	 * Note using this constructor may cause the files not be be flushed until `closeAllWriters` is
+	 * called.
+	 *
+	 * @param parquetFilePath The directory under which the Parquet files are written.
+	 */
+	public ParquetUtil(String parquetFilePath) {
+		this(parquetFilePath, 0, 0, FileSystems.getDefault());
+	}
+	
+	/**
+	 * The preferred constructor for the streaming mode.
+	 *
+	 * @param parquetFilePath The directory under which the Parquet files are written.
+	 * @param secondsToFlush The interval after which the content of Parquet writers is flushed to disk.
+	 * @param rowGroupSize The approximate size of row-groups in the Parquet files (0 means use
+	 *            default).
+	 */
+	public ParquetUtil(String parquetFilePath, int secondsToFlush, int rowGroupSize) {
+		this(parquetFilePath, secondsToFlush, rowGroupSize, FileSystems.getDefault());
+	}
+	
+	@VisibleForTesting
+	ParquetUtil(String parquetFilePath, int secondsToFlush, int rowGroupSize, FileSystem fileSystem) {
 		this.fhirContext = FhirContext.forDstu3();
 		this.converterMap = new HashMap<>();
 		this.writerMap = new HashMap<>();
 		this.parquetFilePath = parquetFilePath;
+		this.rowGroupSize = rowGroupSize;
+		this.fileSystem = fileSystem;
+		if (secondsToFlush > 0) {
+			TimerTask task = new TimerTask() {
+				
+				@Override
+				public void run() {
+					try {
+						flushAll();
+					}
+					catch (IOException e) {
+						log.error("Could not flush Parquet files: " + e);
+					}
+				}
+			};
+			new Timer().scheduleAtFixedRate(task, secondsToFlush * 1000, secondsToFlush * 1000);
+		}
 	}
 	
 	synchronized private AvroConverter getConverter(String resourceType) {
@@ -80,32 +137,77 @@ public class ParquetUtil {
 		return converterMap.get(resourceType);
 	}
 	
-	/**
-	 * This is to fetch a writer for a given `resourceType`; internally it only once create a writer for
-	 * a `resourceType` and on subsequent calls, return the same object. The base path comes from
-	 * `file.parquetPath` system property. NOTE: This should be removed once we move the streaming
-	 * pipeline to Beam; the I/O should be left to Beam similar to the batch mode.
-	 */
-	synchronized public ParquetWriter<GenericRecord> getWriter(String resourceType) throws IOException {
-		Preconditions.checkNotNull(getParquetPath());
-		if (!writerMap.containsKey(resourceType)) {
-			AvroParquetWriter.Builder<GenericRecord> builder = AvroParquetWriter
-			        .builder(new Path(getParquetPath() + resourceType));
-			// TODO adjust parquet file parameters for our needs or make them configurable.
-			ParquetWriter<GenericRecord> writer = builder.withSchema(getResourceSchema(resourceType)).build();
-			writerMap.put(resourceType, writer);
+	@VisibleForTesting
+	synchronized Path bestOutputFile(String resourceType) throws IOException {
+		java.nio.file.Path outputDir = fileSystem.getPath(getParquetPath(), resourceType);
+		Files.createDirectories(outputDir);
+		Stream<java.nio.file.Path> files = Files.list(outputDir);
+		Optional<Integer> maxIndex = files.map(f -> {
+			Matcher matcher = OUTPUT_PATTERN.matcher(f.toString());
+			if (matcher.matches()) {
+				return new Integer(matcher.group(1).replaceFirst("^0+(?!$)", ""));
+			}
+			return -1;
+		}).max(Integer::compareTo);
+		int bestIndex = maxIndex.map(integer -> integer + 1).orElse(0);
+		if (bestIndex > 99999) {
+			// TODO: Handle cases with more than 100K files in a directory, e.g., by creating an extra
+			// layer in the directory hierarchy.
+			throw new IOException(
+			        "It is not wise to create more than 100K files in a directory, please adjust your configuration params!");
 		}
-		return writerMap.get(resourceType);
+		String bestFileName = String.format("output-streaming-%05d", bestIndex);
+		Path bestFilePath = new Path(Paths.get(getParquetPath(), resourceType).toString(), bestFileName);
+		log.info("Creating new Parguet file " + bestFilePath);
+		return bestFilePath;
 	}
 	
-	synchronized public void closeAllWriters() {
+	synchronized private void craeteWriter(String resourceType) throws IOException {
+		// TODO: Find a way to convince Hadoop file operations to use `fileSystem` (needed for testing).
+		AvroParquetWriter.Builder<GenericRecord> builder = AvroParquetWriter.builder(bestOutputFile(resourceType));
+		// TODO: Adjust other parquet file parameters for our needs or make them configurable.
+		if (rowGroupSize > 0) {
+			builder.withRowGroupSize(rowGroupSize);
+		}
+		ParquetWriter<GenericRecord> writer = builder.withSchema(getResourceSchema(resourceType)).build();
+		writerMap.put(resourceType, writer);
+	}
+	
+	/**
+	 * This is to write a FHIR resource to a Parquet file. This automatically handles file creation in a
+	 * directory named after the resource type (e.g., `Patient`) with names following the
+	 * "output-streaming-ddddd" pattern where `ddddd` is a string with five digits. NOTE: This should
+	 * not be used in its current form once we move the streaming pipeline to Beam; the I/O should be
+	 * left to Beam similar to the batch mode.
+	 */
+	synchronized public void write(Resource resource) throws IOException {
+		Preconditions.checkNotNull(getParquetPath());
+		Preconditions.checkNotNull(resource.fhirType());
+		String resourceType = resource.fhirType();
+		if (!writerMap.containsKey(resourceType)) {
+			craeteWriter(resourceType);
+		}
+		final ParquetWriter<GenericRecord> parquetWriter = writerMap.get(resourceType);
+		parquetWriter.write(this.convertToAvro(resource));
+	}
+	
+	synchronized private void flush(String resourceType) throws IOException {
+		ParquetWriter<GenericRecord> writer = writerMap.get(resourceType);
+		if (writer != null && writer.getDataSize() > 0) {
+			writer.close();
+			craeteWriter(resourceType);
+		}
+	}
+	
+	synchronized private void flushAll() throws IOException {
+		for (String resourceType : writerMap.keySet()) {
+			flush(resourceType);
+		}
+	}
+	
+	synchronized public void closeAllWriters() throws IOException {
 		for (Map.Entry<String, ParquetWriter<GenericRecord>> entry : writerMap.entrySet()) {
-			try {
-				entry.getValue().close();
-			}
-			catch (IOException e) {
-				log.error(String.format("Cannot close writer for resource %s exception: %s", entry.getKey(), e));
-			}
+			entry.getValue().close();
 		}
 	}
 	
@@ -131,7 +233,8 @@ public class ParquetUtil {
 		return records;
 	}
 	
-	public GenericRecord convertToAvro(Resource resource) {
+	@VisibleForTesting
+	GenericRecord convertToAvro(Resource resource) {
 		org.hl7.fhir.dstu3.model.Resource r3Resource = org.hl7.fhir.convertors.VersionConvertor_30_40
 		        .convertResource(resource, true);
 		AvroConverter converter = getConverter(r3Resource.getResourceType().name());

--- a/common/src/test/java/org/openmrs/analytics/ParquetUtilTest.java
+++ b/common/src/test/java/org/openmrs/analytics/ParquetUtilTest.java
@@ -19,12 +19,20 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import com.google.common.io.Resources;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericRecord;
@@ -33,9 +41,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParquetUtilTest {
+	
+	private static final Logger log = LoggerFactory.getLogger(ParquetUtil.class);
+	
+	private static final String PARQUET_ROOT = "/parquet_root";
 	
 	private String patientBundle;
 	
@@ -45,13 +59,20 @@ public class ParquetUtilTest {
 	
 	private FhirContext fhirContext;
 	
+	private FileSystem fileSystem;
+	
+	private Path rootPath;
+	
 	@Before
 	public void setup() throws IOException {
-		String parquetFilePath = "/tmp";
+		fileSystem = Jimfs.newFileSystem(Configuration.unix());
+		rootPath = fileSystem.getPath(PARQUET_ROOT);
+		Files.createDirectories(rootPath);
+		ParquetUtil.initializeAvroConverters();
 		patientBundle = Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);
 		observationBundle = Resources.toString(Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
 		this.fhirContext = FhirContext.forR4();
-		parquetUtil = new ParquetUtil(parquetFilePath);
+		parquetUtil = new ParquetUtil(PARQUET_ROOT, 0, 0, fileSystem);
 	}
 	
 	@Test
@@ -111,5 +132,87 @@ public class ParquetUtilTest {
 		assertThat(addressList.size(), equalTo(1));
 		Record address = (Record) addressList.iterator().next();
 		assertThat((String) address.get("city"), equalTo("Waterloo"));
+	}
+	
+	@Test
+	public void bestOutputFile_NoDir() throws IOException {
+		org.apache.hadoop.fs.Path bestFile = parquetUtil.bestOutputFile("Patient");
+		assertThat(bestFile.toString(), equalTo("/parquet_root/Patient/output-streaming-00000"));
+	}
+	
+	@Test
+	public void bestOutputFile_NoFiles() throws IOException {
+		Path patientPath = rootPath.resolve("Patient");
+		Files.createDirectory(patientPath);
+		org.apache.hadoop.fs.Path bestFile = parquetUtil.bestOutputFile("Patient");
+		assertThat(bestFile.toString(), equalTo("/parquet_root/Patient/output-streaming-00000"));
+	}
+	
+	@Test
+	public void bestOutputFile_SomeFiles() throws IOException {
+		Path patientPath = rootPath.resolve("Patient");
+		Files.createDirectory(patientPath);
+		Files.createFile(patientPath.resolve("output-streaming-00000"));
+		Files.createFile(patientPath.resolve("output-streaming-00010"));
+		Files.createFile(patientPath.resolve("output-streaming-00005"));
+		org.apache.hadoop.fs.Path bestFile = parquetUtil.bestOutputFile("Patient");
+		assertThat(bestFile.toString(), equalTo("/parquet_root/Patient/output-streaming-00011"));
+	}
+	
+	private void initilizeLocalFileSystem() throws IOException {
+		// TODO: if we could convince ParquetWriter to use an input FileSystem we could use `Jimfs`.
+		fileSystem = FileSystems.getDefault();
+		rootPath = Files.createTempDirectory("PARQUET_TEST");
+		log.info("Temporary directory is " + rootPath);
+	}
+	
+	@Test
+	public void createSingleOutput() throws IOException {
+		initilizeLocalFileSystem();
+		parquetUtil = new ParquetUtil(rootPath.toString(), 0, 0, fileSystem);
+		IParser parser = fhirContext.newJsonParser();
+		Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
+		for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+			parquetUtil.write(entry.getResource());
+		}
+		parquetUtil.closeAllWriters();
+		Stream<Path> files = Files.list(rootPath.resolve("Observation"))
+		        .filter(f -> f.toString().startsWith(rootPath.toString() + "/Observation/output-"));
+		assertThat(files.count(), equalTo(1L));
+	}
+	
+	@Test
+	public void createMultipleOutputByTime() throws IOException, InterruptedException {
+		initilizeLocalFileSystem();
+		parquetUtil = new ParquetUtil(rootPath.toString(), 1, 0, fileSystem);
+		IParser parser = fhirContext.newJsonParser();
+		Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
+		for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+			parquetUtil.write(entry.getResource());
+			TimeUnit.SECONDS.sleep(2); // A better way to test this is to inject a mocked `Timer`.
+		}
+		parquetUtil.closeAllWriters();
+		Stream<Path> files = Files.list(rootPath.resolve("Observation"))
+		        .filter(f -> f.toString().startsWith(rootPath.toString() + "/Observation/output-"));
+		assertThat(files.count(), equalTo(7L));
+	}
+	
+	@Test
+	public void createSingleOutputWithRowGroupSize() throws IOException {
+		initilizeLocalFileSystem();
+		parquetUtil = new ParquetUtil(rootPath.toString(), 0, 1, fileSystem);
+		IParser parser = fhirContext.newJsonParser();
+		Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
+		// There are 7 resources in the bundle so we write 15*7 (>100) resources, such that the page
+		// group size check is triggered but still it is expected to generate one file only.
+		for (int i = 0; i < 15; i++) {
+			for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+				parquetUtil.write(entry.getResource());
+			}
+		}
+		parquetUtil.closeAllWriters();
+		Stream<Path> files = Files.list(rootPath.resolve("Observation"))
+		        .filter(f -> f.toString().startsWith(rootPath.toString() + "/Observation/output-"));
+		assertThat(files.count(), equalTo(1L));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
     <junit.version>4.13-beta-3</junit.version>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j2.version>2.13.3</log4j2.version>
@@ -320,6 +318,14 @@
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/streaming-binlog/src/test/java/org/openmrs/analytics/FhirConverterTest.java
+++ b/streaming-binlog/src/test/java/org/openmrs/analytics/FhirConverterTest.java
@@ -18,13 +18,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import io.debezium.data.Envelope.Operation;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit4.CamelTestSupport;
-import org.apache.parquet.hadoop.ParquetWriter;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Resource;
 import org.junit.Test;
@@ -56,9 +54,6 @@ public class FhirConverterTest extends CamelTestSupport {
 	
 	@Mock
 	private ParquetUtil parquetUtil;
-	
-	@Mock
-	private ParquetWriter<GenericRecord> parquetWriter;
 	
 	private FhirConverter fhirConverter;
 	
@@ -102,16 +97,13 @@ public class FhirConverterTest extends CamelTestSupport {
 		final String testPath = "some_test_path";
 		Mockito.when(openmrsUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
 		Mockito.when(parquetUtil.getParquetPath()).thenReturn(testPath);
-		Mockito.when(parquetUtil.getWriter("Encounter")).thenReturn(parquetWriter);
 		
 		// Actual event that will trigger process().
 		eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 		
 		Mockito.verify(openmrsUtil).fetchFhirResource(Mockito.anyString());
 		Mockito.verify(fhirStoreUtil, Mockito.never()).uploadResource(Mockito.<Resource> any());
-		Mockito.verify(parquetUtil).getWriter("Encounter");
-		Mockito.verify(parquetUtil).convertToAvro(resource);
-		Mockito.verify(parquetWriter, Mockito.times(1)).write(Mockito.<GenericRecord> any());
+		Mockito.verify(parquetUtil, Mockito.times(1)).write(Mockito.<Resource> any());
 	}
 	
 	@Test


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->
Note the time based policy create new files simulating the idea of windowing in Beam. The row-group-size based policy
just flushes the content as a row-group which has size and performance implications but no new file is generated.

Partially fixes #65 

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:
Ran the following for a set of events with a few thousand Observations and checked that during the time pipeline was running:
- The Observation Parquet files were being flushed because of the row-group-size limit.
- New files were created every 2 minutes (because of `--secondsToFlushParquetFiles=120`).
```
$ mvn exec:java -pl streaming-binlog "-Dexec.args=--databaseHostName=localhost \
  --databasePort=3306 --databaseUser=[DBUSER] --databasePassword=[DBPASS] \
  --databaseSchema=no-atomfeed-p9021-v11S --databaseServerId=77 --databaseOffsetStorage=tmp/offset_TEMP.dat \
  --databaseHistory=tmp/dbhistory_TEMP.dat --openmrsServerUrl=http://localhost:9021 \
  --fileParquetPath=tmp/TEST_streaming_inc_large/ --secondsToFlushParquetFiles=120 \
  --rowGroupSizeForParquetFiles=1000"
```

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note, when in conflict, OpenMRS style guide overrules.

- [X] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

