### PR TITLE
Add support for having both FHIR store and Parquet output enabled at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ mvn exec:java -pl streaming-atomfeed \
     -Dexec.args=" --openmrsUserName=admin --openmrsPassword=Admin123 \
     --openmrsServerUrl=http://localhost:8099/openmrs \
     --fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME \
-    --sinkUser=hapi --sinkPassword=hapi "`
+    --sinkUserName=hapi --sinkPassword=hapi "`
 ```
 
 - `openmrsServerUrl` is the path to your source OpenMRS instance (e.g., `http://localhost:9016/openmrs` in this case)
@@ -185,14 +185,15 @@ $ mvn compile exec:java -pl streaming-binlog \
     --databaseOffsetStorage=offset.dat --databaseHistory=dbhistory.dat \
     --openmrsUserName=admin --openmrsPassword=Admin123 \
     --openmrsServerUrl=http://localhost:8099/openmrs \
-    --openmrsfhirBaseEndpoint=/openmrs/ws/fhir2/R4 \
+    --openmrsfhirBaseEndpoint=/ws/fhir2/R4 \
     --snapshotMode=initial \
     --fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME \
-    --sinkUser=hapi --sinkPassword=hapi \
+    --sinkUserName=hapi --sinkPassword=hapi \
     --fileParquetPath=/tmp/ \
     --fhirDebeziumEventConfigPath=./utils/dbz_event_to_fhir_config.json"
  ```
-NOTE : In order to export data to a fhir sink instead of generating Parquet files,do not pass the '--fileParquetPath' argument 
+NOTE : In order to export data to a fhir sink , pass the '--fhirSinkPath' argument , 
+In order to  generate Parquet files, pass the '--fileParquetPath' argument 
 ## Common questions
 * **Will I be able to stream historical data that were recorded
 prior to enabling the  `mysql binlog`?** Yes, by default, the pipeline takes a snapshot of the entire
@@ -257,9 +258,11 @@ run using a command like:
 
 ```
 $ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar \
-    org.openmrs.analytics.FhirEtl --serverUrl=http://localhost:9018/openmrs \
+    org.openmrs.analytics.FhirEtl --openmrsServerUrl=http://localhost:9018/openmrs \
     --searchList=Patient,Encounter,Observation --batchSize=20 \
-   --targetParallelism=20 --sinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/`
+   --targetParallelism=20 --fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/ \
+   --sinkUserName=hapi --sinkPassword=hapi --fileParquetPath=tmp/TEST/ \
+   --openmrsUserName=admin --openmrsPassword=Admin123 `
 ```
 The `searchList` argument accepts a comma separated list of FHIR search URLs.
 For example, one can use `Patient?given=Susan` to extract only Patient resources
@@ -270,12 +273,14 @@ If you prefer not to use a bundled jar (e.g., during development in an IDE) you
 can use the Maven exec plugin:
 ```
 $ mvn exec:java -pl batch \
-    "-Dexec.args=--serverUrl=http://localhost:9020/openmrs  --searchList=Observation \
-    --batchSize=20 --targetParallelism=20 --outputParquetBase=tmp/TEST/ \
-    --sinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/ \
-    --sinkUsername=hapi --sinkPassword=hapi "
+    "-Dexec.args= --openmrsServerUrl=http://localhost:9020/openmrs  --searchList=Observation \
+    --batchSize=20 --targetParallelism=20 --fileParquetPath=tmp/TEST/ \
+    --fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/ \
+    --sinkUserName=hapi --sinkPassword=hapi \
+     --openmrsUserName=admin --openmrsPassword=Admin123 "
 ```
-NOTE : In order to export data to a fhir sink instead of generating Parquet files,do not pass the '--outputParquetBase' argument 
+NOTE : In order to export data to a fhir sink , pass the '--fhirSinkPath' , 
+In order to  generate Parquet files, pass the '--fileParquetPath' argument 
 # Using Docker compose
 Alternatively you can spin up the entire pipeline using docker containers by running
 

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -33,6 +33,6 @@ RUN echo 'Batch Job started'
 VOLUME [ "${WORK_DIR}" ]
 
 ENTRYPOINT java -cp app.jar org.openmrs.analytics.FhirEtl \
-           --serverUrl=${SERVER_URL} --username=${USERNAME} --password=${PASSWORD} \
+           --openmrsServerUrl=${SERVER_URL} --openmrsUserName=${USERNAME} --openmrsPassword=${PASSWORD} \
            --searchList=${SEARCH_LIST} --batchSize=${BATCH_SIZE} --targetParallelism=${TARGET_PARALLELISM} \
-           --sinkPath=${SINK_PATH}  --sinkUsername=${SINK_USERNAME} --sinkPassword=${SINK_PASSWORD}
+           --fhirSinkPath=${SINK_PATH}  --sinkUserName=${SINK_USERNAME} --sinkPassword=${SINK_PASSWORD}

--- a/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
@@ -94,9 +94,6 @@ public class FhirEtl {
 		
 		void setOpenmrsPassword(String value);
 		
-		// TODO set the default value of this to empty string once FhirSearchUtil is refactored and GCP
-		// specific parts are taken out. Then add the support for having both FHIR store and Parquet
-		// output enabled at the same time.
 		@Description("The path to the target generic fhir store, or a GCP fhir store with the format: "
 		        + "`projects/[\\w-]+/locations/[\\w-]+/datasets/[\\w-]+/fhirStores/[\\w-]+`, e.g., "
 		        + "`projects/my-project/locations/us-central1/datasets/openmrs_fhir_test/fhirStores/test`")

--- a/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
@@ -58,9 +58,9 @@ public class FhirEtl {
 		 */
 		@Description("OpenMRS server URL")
 		@Required
-		String getServerUrl();
+		String getOpenmrsServerUrl();
 		
-		void setServerUrl(String value);
+		void setOpenmrsServerUrl(String value);
 		
 		@Description("OpenMRS server fhir endpoint")
 		@Default.String("/ws/fhir2/R4")
@@ -84,15 +84,15 @@ public class FhirEtl {
 		
 		@Description("Openmrs BasicAuth Username")
 		@Default.String("admin")
-		String getUsername();
+		String getOpenmrsUserName();
 		
-		void setUsername(String value);
+		void setOpenmrsUserName(String value);
 		
 		@Description("Openmrs BasicAuth Password")
 		@Default.String("Admin123")
-		String getPassword();
+		String getOpenmrsPassword();
 		
-		void setPassword(String value);
+		void setOpenmrsPassword(String value);
 		
 		// TODO set the default value of this to empty string once FhirSearchUtil is refactored and GCP
 		// specific parts are taken out. Then add the support for having both FHIR store and Parquet
@@ -101,15 +101,16 @@ public class FhirEtl {
 		        + "`projects/[\\w-]+/locations/[\\w-]+/datasets/[\\w-]+/fhirStores/[\\w-]+`, e.g., "
 		        + "`projects/my-project/locations/us-central1/datasets/openmrs_fhir_test/fhirStores/test`")
 		@Required
-		String getSinkPath();
+		@Default.String("")
+		String getFhirSinkPath();
 		
-		void setSinkPath(String value);
+		void setFhirSinkPath(String value);
 		
 		@Description("Sink BasicAuth Username")
 		@Default.String("")
-		String getSinkUsername();
+		String getSinkUserName();
 		
-		void setSinkUsername(String value);
+		void setSinkUserName(String value);
 		
 		@Description("Sink BasicAuth Password")
 		@Default.String("")
@@ -119,14 +120,14 @@ public class FhirEtl {
 		
 		@Description("The base name for output Parquet file; for each resource, one fileset will be created.")
 		@Default.String("")
-		String getOutputParquetBase();
+		String getFileParquetPath();
 		
-		void setOutputParquetBase(String value);
+		void setFileParquetPath(String value);
 	}
 	
 	static FhirSearchUtil createFhirSearchUtil(FhirEtlOptions options, FhirContext fhirContext) {
-		return new FhirSearchUtil(createOpenmrsUtil(options.getServerUrl() + options.getServerFhirEndpoint(),
-		    options.getUsername(), options.getPassword(), fhirContext));
+		return new FhirSearchUtil(createOpenmrsUtil(options.getOpenmrsServerUrl() + options.getServerFhirEndpoint(),
+		    options.getOpenmrsUserName(), options.getOpenmrsPassword(), fhirContext));
 	}
 	
 	static OpenmrsUtil createOpenmrsUtil(String sourceUrl, String sourceUser, String sourcePw, FhirContext fhirContext) {
@@ -140,7 +141,7 @@ public class FhirEtl {
 		for (String search : options.getSearchList().split(",")) {
 			List<SearchSegmentDescriptor> segments = new ArrayList<>();
 			segmentMap.put(search, segments);
-			String searchUrl = options.getServerUrl() + options.getServerFhirEndpoint() + "/" + search;
+			String searchUrl = options.getOpenmrsServerUrl() + options.getServerFhirEndpoint() + "/" + search;
 			log.info("searchUrl is " + searchUrl);
 			Bundle searchBundle = fhirSearchUtil.searchByUrl(searchUrl, options.getBatchSize(), SummaryEnum.DATA);
 			if (searchBundle == null) {
@@ -189,9 +190,9 @@ public class FhirEtl {
 		
 		private OpenmrsUtil openmrsUtil;
 		
-		FetchSearchPageFn(String sinkPath, String sinkUsername, String sinkPassword, String sourceUrl, String parquetFile,
-		    String sourceUser, String sourcePw) {
-			this.sinkPath = sinkPath;
+		FetchSearchPageFn(String fhirSinkPath, String sinkUsername, String sinkPassword, String sourceUrl,
+		    String parquetFile, String sourceUser, String sourcePw) {
+			this.sinkPath = fhirSinkPath;
 			this.sinkUsername = sinkUsername;
 			this.sinkPassword = sinkPassword;
 			this.sourceUrl = sourceUrl;
@@ -213,12 +214,13 @@ public class FhirEtl {
 		@ProcessElement
 		public void ProcessElement(@Element SearchSegmentDescriptor segment, OutputReceiver<GenericRecord> out) {
 			Bundle pageBundle = fhirSearchUtil.searchByUrl(segment.searchUrl(), segment.count(), SummaryEnum.DATA);
-			if (parquetFile.isEmpty()) {
-				fhirStoreUtil.uploadBundle(pageBundle);
-			} else {
+			if (!parquetFile.isEmpty()) {
 				for (GenericRecord record : parquetUtil.generateRecords(pageBundle)) {
 					out.output(record);
 				}
+			}
+			if (!sinkPath.isEmpty()) {
+				fhirStoreUtil.uploadBundle(pageBundle);
 			}
 		}
 	}
@@ -232,7 +234,7 @@ public class FhirEtl {
 	}
 	
 	static void runFhirFetch(FhirEtlOptions options, FhirContext fhirContext) throws CannotProvideCoderException {
-		ParquetUtil parquetUtil = new ParquetUtil(options.getOutputParquetBase());
+		ParquetUtil parquetUtil = new ParquetUtil(options.getFileParquetPath());
 		Map<String, List<SearchSegmentDescriptor>> segmentMap = createSegments(options, fhirContext);
 		if (segmentMap.isEmpty()) {
 			return;
@@ -241,16 +243,16 @@ public class FhirEtl {
 		Pipeline p = Pipeline.create(options);
 		for (Map.Entry<String, List<SearchSegmentDescriptor>> entry : segmentMap.entrySet()) {
 			String outputFile = "";
-			if (!options.getOutputParquetBase().isEmpty()) {
-				outputFile = options.getOutputParquetBase() + entry.getKey();
+			if (!options.getFileParquetPath().isEmpty()) {
+				outputFile = options.getFileParquetPath() + entry.getKey();
 			}
 			String resourceType = findSearchedResource(entry.getKey());
 			Schema schema = parquetUtil.getResourceSchema(resourceType);
 			PCollection<SearchSegmentDescriptor> inputSegments = p.apply(Create.of(entry.getValue()));
 			PCollection<GenericRecord> records = inputSegments
-			        .apply(ParDo.of(new FetchSearchPageFn(options.getSinkPath(), options.getSinkUsername(),
-			                options.getSinkPassword(), options.getServerUrl() + options.getServerFhirEndpoint(),
-			                options.getOutputParquetBase(), options.getUsername(), options.getPassword())))
+			        .apply(ParDo.of(new FetchSearchPageFn(options.getFhirSinkPath(), options.getSinkUserName(),
+			                options.getSinkPassword(), options.getOpenmrsServerUrl() + options.getServerFhirEndpoint(),
+			                options.getFileParquetPath(), options.getOpenmrsUserName(), options.getOpenmrsPassword())))
 			        .setCoder(AvroCoder.of(GenericRecord.class, schema));
 			ParquetIO.Sink sink = ParquetIO.sink(schema);
 			records.apply(FileIO.<GenericRecord> write().via(sink).to(outputFile));

--- a/common/src/main/java/org/openmrs/analytics/BaseArgs.java
+++ b/common/src/main/java/org/openmrs/analytics/BaseArgs.java
@@ -27,16 +27,16 @@ public class BaseArgs {
 	public String openmrsServerUrl = "http://localhost:8099/openmrs";
 	
 	@Parameter(names = { "--fhirSinkPath" }, description = "Google cloud FHIR store or target generic fhir store")
-	public String fhirSinkPath = "projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME";
+	public String fhirSinkPath = "";
 	
-	@Parameter(names = { "--sinkUser" }, description = "Sink BasicAuth Username")
-	public String sinkUser = "";
+	@Parameter(names = { "--sinkUserName" }, description = "Sink BasicAuth Username")
+	public String sinkUserName = "";
 	
 	@Parameter(names = { "--sinkPassword" }, description = "Sink BasicAuth Password")
 	public String sinkPassword = "";
 	
 	@Parameter(names = { "--fileParquetPath" }, description = "The base path for output Parquet files")
-	public String fileParquetPath;
+	public String fileParquetPath = "";
 	
 	@Parameter(names = { "--secondsToFlushParquetFiles" }, description = "The number of seconds after which all Parquet "
 	        + "writers with non-empty content are flushed to files; use 0 to disable.")

--- a/common/src/main/java/org/openmrs/analytics/FhirStoreUtil.java
+++ b/common/src/main/java/org/openmrs/analytics/FhirStoreUtil.java
@@ -118,4 +118,8 @@ public class FhirStoreUtil {
 	static boolean matchesGcpPattern(String gcpFhirStore) {
 		return GCP_PATTERN.matcher(gcpFhirStore).matches();
 	}
+	
+	public String getSinkUrl() {
+		return this.sinkUrl;
+	}
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,13 +43,17 @@ services:
       - ./utils/dbz_event_to_fhir_config.json:/deployments/utils/dbz_event_to_fhir_config.json
     environment:
       - JAVA_MAIN_CLASS=org.openmrs.analytics.Runner
-      - JAVA_OPTIONS=-Ddatabase.hostname=localhost -Ddatabase.port=3306 -Ddatabase.user=root -Ddatabase.password=debezium
-                     -Ddatabase.dbname=mysql -Ddatabase.schema=openmrs -Ddatabase.serverId=77 -Ddatabase.offsetStorage=/tmp/offset.dat
-                     -Ddatabase.databaseHistory=/tmp/dbhistory.dat -Dopenmrs.username=admin -Dopenmrs.password=Admin123
-                     -Dopenmrs.serverUrl=http://localhost:8099 -Dopenmrs.fhirBaseEndpoint=/openmrs/ws/fhir2/R4
-                     -Dfhir.sinkPath=http://localhost:8098/fhir
-                     -Dfile.parquetPath=/tmp/
-                     -Dfhir.debeziumEventConfigPath=dbz_event_to_fhir_config.json
+      - JAVA_OPTIONS=--databaseHostName=localhost 
+                     --databasePort=3306 --databaseUser=root --databasePassword=debezium 
+                     --databaseName=mysql --databaseSchema=openmrs --databaseServerId=77 
+                     --databaseOffsetStorage=offset.dat --databaseHistory=/tmp/dbhistory.dat 
+                     --openmrsUserName=admin --openmrsPassword=Admin123 
+                     --openmrsServerUrl=http://localhost:8099/openmrs 
+                     --openmrsfhirBaseEndpoint=/ws/fhir2/R4 
+                     --snapshotMode=initial 
+                     --fhirSinkPath=http://localhost:8098/fhir
+                     --fileParquetPath=/tmp/ 
+                     --fhirDebeziumEventConfigPath=./utils/dbz_event_to_fhir_config.json
 
   streaming-atomfeed:
     container_name: streaming-atomfeed

--- a/streaming-atomfeed/Dockerfile
+++ b/streaming-atomfeed/Dockerfile
@@ -25,4 +25,4 @@ ENV SINK_USERNAME=""
 ENV SINK_PASSWORD=""
 
 ENTRYPOINT mvn exec:java -pl streaming-atomfeed -Dexec.mainClass=org.openmrs.analytics.FhirStreaming \
-    -Dexec.args="--openmrsServerUrl=$SOURCE_URL --openmrsUserName=$SOURCE_USERNAME --openmrsPassword=$SOURCE_PW --fhirSinkPath=$SINK_URL --sinkUser=$SINK_USERNAME --sinkPassword=$SINK_PASSWORD"
+    -Dexec.args="--openmrsServerUrl=$SOURCE_URL --openmrsUserName=$SOURCE_USERNAME --openmrsPassword=$SOURCE_PW --fhirSinkPath=$SINK_URL --sinkUserName=$SINK_USERNAME --sinkPassword=$SINK_PASSWORD"

--- a/streaming-atomfeed/src/main/java/org/openmrs/analytics/FhirStreaming.java
+++ b/streaming-atomfeed/src/main/java/org/openmrs/analytics/FhirStreaming.java
@@ -57,7 +57,7 @@ public class FhirStreaming {
 		sourceUser = streamingArgs.openmrUserName;
 		sourcePassword = streamingArgs.openmrsPassword;
 		sinkPath = streamingArgs.fhirSinkPath;
-		sinkUser = streamingArgs.sinkUser;
+		sinkUser = streamingArgs.sinkUserName;
 		sinkPassword = streamingArgs.sinkPassword;
 		
 		String feedUrl = sourceUrl + FEED_ENDPOINT;

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -58,7 +58,7 @@ public class DebeziumListener extends RouteBuilder {
 		FhirContext fhirContext = FhirContext.forR4();
 		String fhirBaseUrl = params.openmrsServerUrl + params.openmrsfhirBaseEndpoint;
 		OpenmrsUtil openmrsUtil = new OpenmrsUtil(fhirBaseUrl, params.openmrUserName, params.openmrsPassword, fhirContext);
-		FhirStoreUtil fhirStoreUtil = FhirStoreUtil.createFhirStoreUtil(params.fhirSinkPath, params.sinkUser,
+		FhirStoreUtil fhirStoreUtil = FhirStoreUtil.createFhirStoreUtil(params.fhirSinkPath, params.sinkUserName,
 		    params.sinkPassword, fhirContext.getRestfulClientFactory());
 		ParquetUtil parquetUtil = new ParquetUtil(params.fileParquetPath, params.secondsToFlushParquetFiles,
 		        params.rowGroupSizeForParquetFiles);

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/FhirConverter.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/FhirConverter.java
@@ -104,16 +104,18 @@ public class FhirConverter implements Processor {
 			return;
 		}
 		
-		if (parquetUtil.getParquetPath() != null) {
+		if (!parquetUtil.getParquetPath().isEmpty()) {
 			try {
 				parquetUtil.write(resource);
 			}
 			catch (IOException e) {
 				log.error(String.format("Cannot create ParquetWriter Exception: %s", e));
 			}
-		} else {
+		}
+		if (!fhirStoreUtil.getSinkUrl().isEmpty()) {
 			fhirStoreUtil.uploadResource(resource);
 		}
+		
 	}
 	
 	@VisibleForTesting


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed

- Add support for having both FHIR store and Parquet output enabled at the same time  . This is controlled by passing the` --fhirSinkPath`  and '--fileParquetPath' arguments or leaving them out 

-  I also corrected the parameter naming to have uniform argument names throughout the three sub-modules

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:
```
mvn compile exec:java -pl streaming-binlog \
   -Dexec.args="--databaseHostName=localhost \
   --databasePort=3308 --databaseUser=root --databasePassword=Admin123\
   --databaseName=mysql --databaseSchema=openmrs --databaseServerId=223344 \
   --openmrsUserName=admin --openmrsPassword=Admin123 \
   --openmrsServerUrl=http://localhost:8081/openmrs \
   --fhirSinkPath=http://localhost:8888/fhir \
   --sinkUserName=hapi --sinkPassword=hapi123 \
   --fileParquetPath=/tmp/" 
   
```
   
   
   ```
 mvn compile  exec:java -pl streaming-atomfeed \
    -Dexec.args="--openmrsUserName=admin --openmrsPassword=Admin123 \
    --openmrsServerUrl=http://localhost:8081/openmrs \
    --fhirSinkPath=http://localhost:8888/fhir \
    --sinkUserName=hapi --sinkPassword=hapi123 "
    
```
    
    
```
mvn compile exec:java -pl batch \
    "-Dexec.args=--openmrsServerUrl=http://localhost:8081/openmrs  --searchList=Patient \
    --batchSize=20 --targetParallelism=20  \
    --fhirSinkPath=http://localhost:8888/fhir \
    --sinkUserName=hapi --sinkPassword=hapi123 \
    --openmrsUserName=admin --openmrsPassword=Admin123 \
    --fileParquetPath=/tmp/
    "
```

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note, when in conflict, OpenMRS style guide overrules.

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

