### PR TITLE
changed the default of batchSize flag

### DIFF
--- a/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
@@ -85,7 +85,7 @@ public class FhirEtl {
 		
 		@Description("The number of resources to be fetched in one API call. "
 		        + "For the JDBC mode passing > 170 could result in HTTP 400 Bad Request")
-		@Default.Integer(170)
+		@Default.Integer(100)
 		int getBatchSize();
 		
 		void setBatchSize(int value);
@@ -194,6 +194,11 @@ public class FhirEtl {
 	
 	static Map<String, List<SearchSegmentDescriptor>> createSegments(FhirEtlOptions options, FhirContext fhirContext)
 	        throws CannotProvideCoderException {
+		if (options.getBatchSize() > 100) {
+			// TODO: Probe this value from the server and set the maximum automatically.
+			log.warn("NOTE batchSize flag is higher than 100; make sure that `fhir2.paging.maximum` "
+			        + "is set accordingly on the OpenMRS server.");
+		}
 		FhirSearchUtil fhirSearchUtil = createFhirSearchUtil(options, fhirContext);
 		Map<String, List<SearchSegmentDescriptor>> segmentMap = new HashMap<>();
 		for (String search : options.getSearchList().split(",")) {


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed
Fixes #94 
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:
Ran
```
java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar org.openmrs.analytics.FhirEtl --openmrsServerUrl=http://localhost:8099/openmrs --fileParquetPath=tmp/TEST_docker_batch/ --searchList=Patient
```
then verified that the number of patients is 1000 which is the same in the test data set:
```
java -jar ~/git_repos/read_only/parquet-mr/parquet-tools/target/parquet-tools-1.12.0-SNAPSHOT.jar rowcount tmp/TEST_docker_batch/Patient/
```

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note, when in conflict, OpenMRS style guide overrules.

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  No, manually e2e tested this.

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

