### PR TITLE
Move:move debezium specific settings to a json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ $ mvn compile exec:java -pl streaming-binlog
 $ mvn compile exec:java -pl streaming-binlog \
     -Dexec.args="--databaseHostName=localhost \
     --databasePort=3306 --databaseUser=root --databasePassword=debezium \
-    --databaseName=mysql --databaseSchema=openmrs --databaseServerId=77 \
+    --databaseName=mysql --databaseSchema=openmrs --databaseServerId=223344 \
     --databaseOffsetStorage=offset.dat --databaseHistory=dbhistory.dat \
     --openmrsUserName=admin --openmrsPassword=Admin123 \
     --openmrsServerUrl=http://localhost:8099/openmrs \
@@ -467,7 +467,7 @@ for streaming
     mvn compile exec:java -pl streaming-binlog \
       -Dexec.args="--databaseHostName=localhost \
       --databasePort=3306 --databaseUser=root --databasePassword=debezium\
-      --databaseName=mysql --databaseSchema=openmrs --databaseServerId=77 \
+      --databaseName=mysql --databaseSchema=openmrs --databaseServerId=223344 \
       --openmrsUserName=admin --openmrsPassword=Admin123 \
       --openmrsServerUrl=http://localhost:8099/openmrs \
       --fhirSinkPath=http://localhost:5001/fhir \

--- a/README.md
+++ b/README.md
@@ -180,16 +180,14 @@ $ mvn compile exec:java -pl streaming-binlog
  ```
 $ mvn compile exec:java -pl streaming-binlog \
     -Dexec.args="--databaseHostName=localhost \
-    --databasePort=3306 --databaseUser=root --databasePassword=debezium \
-    --databaseName=mysql --databaseSchema=openmrs --databaseServerId=223344 \
-    --databaseOffsetStorage=offset.dat --databaseHistory=dbhistory.dat \
+    --databaseUser=root --databasePassword=debezium \
+    --databaseSchema=openmrs \
     --openmrsUserName=admin --openmrsPassword=Admin123 \
     --openmrsServerUrl=http://localhost:8099/openmrs \
     --openmrsfhirBaseEndpoint=/ws/fhir2/R4 \
     --snapshotMode=initial \
     --fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME \
-    --sinkUserName=hapi --sinkPassword=hapi \
-    --fileParquetPath=/tmp/ \ "
+    --sinkUserName=hapi --sinkPassword=hapi \"
  ```
 NOTE : In order to export data to a fhir sink , pass the '--fhirSinkPath' argument , 
 In order to  generate Parquet files, pass the '--fileParquetPath' argument 
@@ -466,13 +464,12 @@ for streaming
 
     mvn compile exec:java -pl streaming-binlog \
       -Dexec.args="--databaseHostName=localhost \
-      --databasePort=3306 --databaseUser=root --databasePassword=debezium\
-      --databaseName=mysql --databaseSchema=openmrs --databaseServerId=223344 \
+      --databaseUser=root --databasePassword=debezium\
+      --databaseSchema=openmrs \
       --openmrsUserName=admin --openmrsPassword=Admin123 \
       --openmrsServerUrl=http://localhost:8099/openmrs \
       --fhirSinkPath=http://localhost:5001/fhir \
-      --sinkUserName=hapi --sinkPassword=Admin123 \
-      --fileParquetPath=/tmp/" 
+      --sinkUserName=hapi --sinkPassword=Admin123 \" 
       
 
 You can track all the transactions in the OpenHIM instance Under the Tab `Transaction Log`

--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ $ mvn compile exec:java -pl streaming-binlog \
     --snapshotMode=initial \
     --fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME \
     --sinkUserName=hapi --sinkPassword=hapi \
-    --fileParquetPath=/tmp/ \
-    --fhirDebeziumEventConfigPath=./utils/dbz_event_to_fhir_config.json"
+    --fileParquetPath=/tmp/ \ "
  ```
 NOTE : In order to export data to a fhir sink , pass the '--fhirSinkPath' argument , 
 In order to  generate Parquet files, pass the '--fileParquetPath' argument 

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -126,29 +126,14 @@ public class DebeziumListener extends RouteBuilder {
 		@Parameter(names = { "--databaseHostName" }, description = "Host name on which the source database runs")
 		public String databaseHostName = "localhost";
 		
-		@Parameter(names = { "--databasePort" }, description = "Port of the source database")
-		public Integer databasePort = 3306;
-		
 		@Parameter(names = { "--databaseUser" }, description = "User name of the host Database")
 		public String databaseUser = "root";
 		
 		@Parameter(names = { "--databasePassword" }, description = "Passowrd for the user of the host Database")
 		public String databasePassword = "debezium";
 		
-		@Parameter(names = { "--databaseName" }, description = "Name Database")
-		public String databaseName = "mysql";
-		
 		@Parameter(names = { "--databaseSchema" }, description = "Name the Schema")
 		public String databaseSchema = "openmrs";
-		
-		@Parameter(names = { "--databaseServerId" }, description = "Server Id of the source database")
-		public Integer databaseServerId = 223344;
-		
-		@Parameter(names = { "--databaseOffsetStorage" }, description = "Database OffsetStorage setting")
-		public String databaseOffsetStorage = "data/offset.dat";
-		
-		@Parameter(names = { "--databaseHistory" }, description = "replacing Offset by History")
-		public String databaseHistory = "data/dbhistory.dat";
 		
 		@Parameter(names = { "--snapshotMode" }, description = "criteria for running DB snapshot, options include: "
 		        + "when_needed, schema_only, initial, never, e.t.c. To read events from day 0 of db data-entry, use 'initial'. "

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -71,14 +71,14 @@ public class DebeziumListener extends RouteBuilder {
 		GeneralConfiguration gc = new GeneralConfiguration();
 		GeneralConfiguration generalConfiguration = gc.getFhirDebeziumConfigPath(params.fhirDebeziumConfigPath);
 		return "debezium-mysql:" + generalConfiguration.getDbzConfigs().get("databaseHostName") + "?" + "databaseHostname="
-		        + generalConfiguration.getDbzConfigs().get("databaseName") + "&databaseServerId="
+		        + generalConfiguration.getDbzConfigs().get("databaseHostName") + "&databaseServerId="
 		        + generalConfiguration.getDbzConfigs().get("databaseServerId") + "&databasePort="
 		        + generalConfiguration.getDbzConfigs().get("databasePort") + "&databaseUser="
 		        + generalConfiguration.getDbzConfigs().get("databaseUser") + "&databasePassword="
 		        + generalConfiguration.getDbzConfigs().get("databasePassword") + "&databaseServerName="
 		        + generalConfiguration.getDbzConfigs().get("databaseName") + "&databaseWhitelist="
-		        + generalConfiguration.getDbzConfigs().get("databaseSchema") + "&offsetStorage="
-		        + generalConfiguration.getDbzConfigs().get("OffsetStorage") + "&offsetStorageFileName="
+		        + generalConfiguration.getDbzConfigs().get("databaseSchema")
+		        + "org.apache.kafka.connect.storage.FileOffsetBackingStore" + "&offsetStorageFileName="
 		        + generalConfiguration.getDbzConfigs().get("databaseOffsetStorage") + "&databaseHistoryFileFilename="
 		        + generalConfiguration.getDbzConfigs().get("databaseHistory") + "&snapshotMode="
 		        + generalConfiguration.getDbzConfigs().get("snapshotMode");

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -70,18 +70,18 @@ public class DebeziumListener extends RouteBuilder {
 	private String getDebeziumConfig() throws IOException {
 		GeneralConfiguration gc = new GeneralConfiguration();
 		GeneralConfiguration generalConfiguration = gc.getFhirDebeziumConfigPath(params.fhirDebeziumConfigPath);
-		return "debezium-mysql:" + generalConfiguration.getDbzConfigs().get("databaseHostName") + "?" + "databaseHostname="
-		        + generalConfiguration.getDbzConfigs().get("databaseHostName") + "&databaseServerId="
-		        + generalConfiguration.getDbzConfigs().get("databaseServerId") + "&databasePort="
-		        + generalConfiguration.getDbzConfigs().get("databasePort") + "&databaseUser="
-		        + generalConfiguration.getDbzConfigs().get("databaseUser") + "&databasePassword="
-		        + generalConfiguration.getDbzConfigs().get("databasePassword") + "&databaseServerName="
-		        + generalConfiguration.getDbzConfigs().get("databaseName") + "&databaseWhitelist="
-		        + generalConfiguration.getDbzConfigs().get("databaseSchema")
+		return "debezium-mysql:" + generalConfiguration.getDebeziumConfigurations().get("databaseHostName") + "?"
+		        + "databaseHostname=" + generalConfiguration.getDebeziumConfigurations().get("databaseHostName")
+		        + "&databaseServerId=" + generalConfiguration.getDebeziumConfigurations().get("databaseServerId")
+		        + "&databasePort=" + generalConfiguration.getDebeziumConfigurations().get("databasePort") + "&databaseUser="
+		        + generalConfiguration.getDebeziumConfigurations().get("databaseUser") + "&databasePassword="
+		        + generalConfiguration.getDebeziumConfigurations().get("databasePassword") + "&databaseServerName="
+		        + generalConfiguration.getDebeziumConfigurations().get("databaseName") + "&databaseWhitelist="
+		        + generalConfiguration.getDebeziumConfigurations().get("databaseSchema")
 		        + "org.apache.kafka.connect.storage.FileOffsetBackingStore" + "&offsetStorageFileName="
-		        + generalConfiguration.getDbzConfigs().get("databaseOffsetStorage") + "&databaseHistoryFileFilename="
-		        + generalConfiguration.getDbzConfigs().get("databaseHistory") + "&snapshotMode="
-		        + generalConfiguration.getDbzConfigs().get("snapshotMode");
+		        + generalConfiguration.getDebeziumConfigurations().get("databaseOffsetStorage")
+		        + "&databaseHistoryFileFilename=" + generalConfiguration.getDebeziumConfigurations().get("databaseHistory")
+		        + "&snapshotMode=" + generalConfiguration.getDebeziumConfigurations().get("snapshotMode");
 	}
 	
 	/**
@@ -142,7 +142,7 @@ public class DebeziumListener extends RouteBuilder {
 		public String databaseSchema = "openmrs";
 		
 		@Parameter(names = { "--databaseServerId" }, description = "Server Id of the source database")
-		public Integer databaseServerId = 77;
+		public Integer databaseServerId = 223344;
 		
 		@Parameter(names = { "--databaseOffsetStorage" }, description = "Database OffsetStorage setting")
 		public String databaseOffsetStorage = "data/offset.dat";

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/model/EventConfiguration.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/model/EventConfiguration.java
@@ -35,4 +35,56 @@ public class EventConfiguration {
 	@Getter
 	@Setter
 	private LinkedHashMap<String, String> linkTemplates;
+	
+	@Getter
+	@Setter
+	private String databaseHostName;
+	
+	@Getter
+	@Setter
+	private int databasePort;
+	
+	@Getter
+	@Setter
+	private String databaseUser;
+	
+	@Getter
+	@Setter
+	private String databasePassword;
+	
+	@Getter
+	@Setter
+	private String databaseName;
+	
+	@Getter
+	@Setter
+	private int databaseServerId;
+	
+	@Getter
+	@Setter
+	private String databaseServerName;
+	
+	@Getter
+	@Setter
+	private String databaseSchema;
+	
+	@Getter
+	@Setter
+	private String offsetStorage;
+	
+	@Getter
+	@Setter
+	private String databaseOffsetStorage;
+	
+	@Getter
+	@Setter
+	private String databaseHistory;
+	
+	@Getter
+	@Setter
+	private String snapshotMode;
+	
+	@Getter
+	@Setter
+	private String openmrsfhirBaseEndpoint;
 }

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/model/EventConfiguration.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/model/EventConfiguration.java
@@ -70,10 +70,6 @@ public class EventConfiguration {
 	
 	@Getter
 	@Setter
-	private String offsetStorage;
-	
-	@Getter
-	@Setter
 	private String databaseOffsetStorage;
 	
 	@Getter

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/model/GeneralConfiguration.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/model/GeneralConfiguration.java
@@ -25,15 +25,13 @@ import com.google.gson.Gson;
 import lombok.Getter;
 import lombok.Setter;
 
+@Getter
+@Setter
 public class GeneralConfiguration {
 	
-	@Getter
-	@Setter
 	private LinkedHashMap<String, EventConfiguration> eventConfigurations;
 	
-	@Getter
-	@Setter
-	private LinkedHashMap<String, String> dbzConfigs;
+	private LinkedHashMap<String, String> debeziumConfigurations;
 	
 	public GeneralConfiguration getFhirDebeziumConfigPath(String fileName) throws IOException {
 		Gson gson = new Gson();

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/model/GeneralConfiguration.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/model/GeneralConfiguration.java
@@ -13,8 +13,15 @@
 // limitations under the License.
 package org.openmrs.analytics.model;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 
+import com.google.gson.Gson;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,6 +31,17 @@ public class GeneralConfiguration {
 	@Setter
 	private LinkedHashMap<String, EventConfiguration> eventConfigurations;
 	
-	// TODO add Debezium config to the model + json
+	@Getter
+	@Setter
+	private LinkedHashMap<String, String> dbzConfigs;
+	
+	public GeneralConfiguration getFhirDebeziumConfigPath(String fileName) throws IOException {
+		Gson gson = new Gson();
+		Path pathToFile = Paths.get(fileName);
+		try (Reader reader = Files.newBufferedReader(pathToFile, StandardCharsets.UTF_8)) {
+			GeneralConfiguration generalConfiguration = gson.fromJson(reader, GeneralConfiguration.class);
+			return generalConfiguration;
+		}
+	}
 	
 }

--- a/streaming-binlog/src/test/java/org/openmrs/analytics/DebeziumListenerTest.java
+++ b/streaming-binlog/src/test/java/org/openmrs/analytics/DebeziumListenerTest.java
@@ -43,7 +43,8 @@ public class DebeziumListenerTest extends CamelTestSupport {
 	protected RoutesBuilder createRouteBuilder() throws Exception {
 		// mock properties
 		String[] args = { "--databaseHostName=hostname", "--databaseUser=root", "--openmrsUserName=user",
-		        "--fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME " };
+		        "--fhirSinkPath=projects/PROJECT/locations/LOCATION/datasets/DATASET/fhirStores/FHIRSTORENAME ",
+		        "--fhirDebeziumConfigPath=../utils/dbz_event_to_fhir_config.json" };
 		
 		// Using a simple mock object would be more work since we need to provide stubs for the superclasses too.
 		fhirConverterMock = new FhirConverter() {

--- a/utils/dbz_event_to_fhir_config.json
+++ b/utils/dbz_event_to_fhir_config.json
@@ -1,4 +1,19 @@
 {
+  "dbzConfigs": {
+    "databaseName" : "mysql",
+    "databaseHostName" : "localhost",
+    "databaseServerId" : "77",
+    "databasePort" : "3306",
+    "databaseUser" : "root",
+    "databasePassword" : "debezium",
+    "databaseServerName" : "mysql",
+    "databaseSchema" : "openmrs",
+    "offsetStorage" : "org.apache.kafka.connect.storage.FileOffsetBackingStore",
+    "databaseOffsetStorage" : "data/offset.dat",
+    "databaseHistory" : "data/dbhistory.dat",
+    "snapshotMode" : "initial",
+    "openmrsfhirBaseEndpoint" : "/ws/fhir2/R4"
+    },
   "eventConfigurations": {
     "location": {
       "enabled": "false",

--- a/utils/dbz_event_to_fhir_config.json
+++ b/utils/dbz_event_to_fhir_config.json
@@ -1,5 +1,5 @@
 {
-  "dbzConfigs": {
+  "debeziumConfigurations": {
     "databaseName" : "mysql",
     "databaseHostName" : "localhost",
     "databaseServerId" : "223344",

--- a/utils/dbz_event_to_fhir_config.json
+++ b/utils/dbz_event_to_fhir_config.json
@@ -2,18 +2,17 @@
   "dbzConfigs": {
     "databaseName" : "mysql",
     "databaseHostName" : "localhost",
-    "databaseServerId" : "77",
+    "databaseServerId" : "223344",
     "databasePort" : "3306",
     "databaseUser" : "root",
     "databasePassword" : "debezium",
     "databaseServerName" : "mysql",
     "databaseSchema" : "openmrs",
-    "offsetStorage" : "org.apache.kafka.connect.storage.FileOffsetBackingStore",
     "databaseOffsetStorage" : "data/offset.dat",
     "databaseHistory" : "data/dbhistory.dat",
     "snapshotMode" : "initial",
     "openmrsfhirBaseEndpoint" : "/ws/fhir2/R4"
-    },
+   },
   "eventConfigurations": {
     "location": {
       "enabled": "false",


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
Issue #51

moved the the debezium settings to `dbz_event_to_fhir_config.json` config file
and also moved the debezium settings to the event configuration class so that we have all the configs together 
e2e test
TESTED:

mvn compile exec:java -pl streaming-binlog \
   -Dexec.args="--databaseHostName=localhost \
   --databaseUser=root --databasePassword=debezium \
   --databaseSchema=openmrs \
   --openmrsUserName=admin --openmrsPassword=Admin123 \
   --openmrsServerUrl=http://localhost:8099/openmrs \
   --openmrsfhirBaseEndpoint=/ws/fhir2/R4 \
   --snapshotMode=schema_only \
   --fhirSinkPath=http://localhost:8098/fhir \
   --sinkUserName= --sinkPassword= "
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/openmrs-fhir-analytics/103)
<!-- Reviewable:end -->
