### PR TITLE
clean-up:changing jdbcUrl port

### DIFF
--- a/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -144,7 +144,7 @@ public class DebeziumListener extends RouteBuilder {
 		public String jdbcDriverClass = "com.mysql.cj.jdbc.Driver";
 		
 		@Parameter(names = { "--jdbcUrl" }, description = "JDBC URL input")
-		public String jdbcUrlInput = "jdbc:mysql://localhost:3308/openmrs";
+		public String jdbcUrlInput = "jdbc:mysql://localhost:3306/openmrs";
 		
 		@Parameter(names = { "--jdbcMaxPoolSize" }, description = "JDBC maximum pool size")
 		public int jdbcMaxPoolSize = 50;


### PR DESCRIPTION
switching the jdbcUrl port from 3308 to 3306 to enable binlog pipeline to run and fetch uuids from parent tables for tables without uuid columns 