### PR TITLE
Added an option to flush output files in chunks

### DIFF
--- a/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
@@ -37,10 +37,15 @@ import org.apache.beam.sdk.io.parquet.ParquetIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.hl7.fhir.r4.model.Bundle;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +107,18 @@ public class FhirEtl {
 		return search;
 	}
 	
+	static <T> PCollection<T> addWindow(PCollection<T> records, int secondsToFlush) {
+		if (secondsToFlush <= 0) {
+			return records;
+		}
+		// We are dealing with a bounded source hence we can simply use the single Global window.
+		// Also we don't need to deal with late data.
+		return records.apply(Window.<T> into(new GlobalWindows())
+		        .triggering(Repeatedly.forever(
+		            AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(secondsToFlush))))
+		        .discardingFiredPanes());
+	}
+	
 	private static void fetchSegments(PCollection<SearchSegmentDescriptor> inputSegments, String search,
 	        FhirEtlOptions options) {
 		String resourceType = findSearchedResource(search);
@@ -112,17 +129,21 @@ public class FhirEtl {
 		    TupleTagList.of(fetchSearchPageFn.jsonTag)));
 		records.get(fetchSearchPageFn.avroTag).setCoder(AvroCoder.of(GenericRecord.class, schema));
 		if (!options.getOutputParquetPath().isEmpty()) {
+			PCollection<GenericRecord> windowedRecords = addWindow(records.get(fetchSearchPageFn.avroTag),
+			    options.getSecondsToFlushFiles());
 			// TODO: Make sure getOutputParquetPath() is a directory.
 			String outputFile = options.getOutputParquetPath() + resourceType;
 			ParquetIO.Sink sink = ParquetIO.sink(schema); // TODO add an option for .withCompressionCodec();
-			records.get(fetchSearchPageFn.avroTag).apply(FileIO.<GenericRecord> write().via(sink).to(outputFile)
-			        .withSuffix(".parquet").withNumShards(options.getNumFileShards()));
+			windowedRecords.apply(FileIO.<GenericRecord> write().via(sink).to(outputFile).withSuffix(".parquet")
+			        .withNumShards(options.getNumFileShards()));
 			// TODO add Avro output option
 			// apply("WriteToAvro", AvroIO.writeGenericRecords(schema).to(outputFile).withSuffix(".avro")
 			//        .withNumShards(options.getNumParquetShards()));
 		}
 		if (!options.getOutputJsonPath().isEmpty()) {
-			records.get(fetchSearchPageFn.jsonTag).apply("WriteToText",
+			PCollection<String> windowedRecords = addWindow(records.get(fetchSearchPageFn.jsonTag),
+			    options.getSecondsToFlushFiles());
+			windowedRecords.apply("WriteToText",
 			    TextIO.write().to(options.getOutputJsonPath() + resourceType).withSuffix(".txt"));
 		}
 	}

--- a/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
@@ -113,6 +113,7 @@ public class FhirEtl {
 		}
 		// We are dealing with a bounded source hence we can simply use the single Global window.
 		// Also we don't need to deal with late data.
+		// TODO: Implement an easy way to unit-test this functionality.
 		return records.apply(Window.<T> into(new GlobalWindows())
 		        .triggering(Repeatedly.forever(
 		            AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(secondsToFlush))))

--- a/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
@@ -165,4 +165,11 @@ public interface FhirEtlOptions extends PipelineOptions {
 	int getNumFileShards();
 	
 	void setNumFileShards(int value);
+	
+	@Description("The number of seconds after which records are flushed into Parquet/text files; "
+	        + "use 0 to disable (note this may have undesired memory implications).")
+	@Default.Integer(600)
+	int getSecondsToFlushFiles();
+	
+	void setSecondsToFlushFiles(int value);
 }


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->
This is to address the incremental Parquet file generation requirements which might be related to Issue #136. With the added `--secondsToFlushFiles` option we can force Beam to generate Parquet files in multiple batches (note this is different from setting `rowGroupSize` which is done differently).

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:
Ran:
```
$ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar org.openmrs.analytics.FhirEtl \
  --openmrsServerUrl=http://localhost:8099/openmrs --jdbcUrl=jdbc:mysql://localhost:3306/openmrs \
  --searchList=Patient,Encounter,Observation --jdbcFetchSize=1000  --jdbcMaxPoolSize=100 --jdbcModeEnabled \
  --targetParallelism=10 --numFileShards=3 --secondsToFlushFiles=180 --outputParquetPath=[PATH]
```
and verified that the files are generated in 3 minutes intervals.

I also tried a similar command with 1 minute intervals and limited JVM heap size to 2 GB; the pipeline did _not_ fail with an out-of-memory exception. Without the trigger option, Parquet generation for Observations takes a long time and eventually fails with OOM so this might be really related to Issue #136 (yet to be confirmed by @kimaina ).

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note, when in conflict, OpenMRS style guide overrules.

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

