### PR TITLE
Date review

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ $ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar \
     --fhirSinkPath=http://localhost:8098/fhir \
     --sinkUserName=hapi --sinkPassword=hapi \
     --outputParquetPath=/tmp/TEST/ \
-    --searchList=Patient,Encounter,Observation --batchSize=20
+    --resourceList=Patient,Encounter,Observation --batchSize=20
 ```
 
 Parameters:
 
--   `searchList` - A comma-separated list of
-    [FHIR Search](https://www.hl7.org/fhir/search.html) URLs. For example,
+-   `resourceList` - A comma-separated list of
+    [FHIR resources](https://www.hl7.org/fhir/resourcelist.html) URLs. For example,
     `Patient?given=Susan` will extract only Patient resources that meet the
     `given=Susan` criteria. Default: `Patient,Encounter,Observation`
 -   `batchSize` - The number of resources to fetch in each API call.
@@ -154,7 +154,7 @@ $ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar \
     --fhirSinkPath=http://localhost:8098/fhir \
     --sinkUserName=hapi --sinkPassword=hapi \
     --outputParquetPath=/tmp/TEST/ \
-    --searchList=Patient,Encounter,Observation --batchSize=20 \
+    --resourceList=Patient,Encounter,Observation --batchSize=20 \
     --jdbcModeEnabled=true --jdbcUrl=jdbc:mysql://localhost:3306/openmrs \
     --dbUser=root --dbPassword=debezium --jdbcMaxPoolSize=50 \
     --jdbcDriverClass=com.mysql.cj.jdbc.Driver
@@ -163,7 +163,7 @@ $ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar \
 
 Parameters:
 
--   `searchList` - A comma-separated list of FHIR Resources to be fetched from
+-   `resourceList` - A comma-separated list of FHIR Resources to be fetched from
     OpenMRS. Default: `Patient,Encounter,Observation`
 -   `batchSize` - The number of resources to fetch in each API call. Default:
     `100`

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -24,7 +24,7 @@ ENV OPENMRS_PASSWORD="Admin123"
 ENV SINK_PATH=""
 ENV SINK_USERNAME=""
 ENV SINK_PASSWORD=""
-ENV SEARCH_LIST="Patient,Encounter,Observation"
+ENV RESOURCE_LIST="Patient,Encounter,Observation"
 ENV BATCH_SIZE=10
 ENV TARGET_PARALLELISM=10
 ENV PARQUET_PATH="/tmp/"
@@ -44,7 +44,7 @@ VOLUME [ "${WORK_DIR}" ]
 
 ENTRYPOINT java -cp app.jar org.openmrs.analytics.FhirEtl \
            --openmrsServerUrl=${OPENMRS_URL} --openmrsUserName=${OPENMRS_USERNAME} --openmrsPassword=${OPENMRS_PASSWORD} \
-           --searchList=${SEARCH_LIST} --batchSize=${BATCH_SIZE} --targetParallelism=${TARGET_PARALLELISM} \
+           --resourceList=${RESOURCE_LIST} --batchSize=${BATCH_SIZE} --targetParallelism=${TARGET_PARALLELISM} \
            --fhirSinkPath=${SINK_PATH}  --sinkUserName=${SINK_USERNAME} --sinkPassword=${SINK_PASSWORD} \
            --outputParquetPath=${PARQUET_PATH} --jdbcModeEnabled=${JDBC_MODE_ENABLED} --jdbcDriverClass=${JDBC_DRIVER_CLASS} \
            --dbUser=${DB_USER} --dbPassword=${DB_PASSWORD} --jdbcMaxPoolSize=${JDBC_MAX_POOL_SIZE} --jdbcUrl=${JDBC_URL} \

--- a/batch/src/main/java/org/openmrs/analytics/FetchPatientHistory.java
+++ b/batch/src/main/java/org/openmrs/analytics/FetchPatientHistory.java
@@ -1,0 +1,86 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.openmrs.analytics;
+
+import java.util.List;
+
+import ca.uhn.fhir.rest.api.SummaryEnum;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.hl7.fhir.r4.model.Bundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetchPatientHistory extends PTransform<PCollection<KV<String, Integer>>, PCollectionTuple> {
+	
+	private static final Logger log = LoggerFactory.getLogger(FetchPatientHistory.class);
+	
+	private final FetchSearchPageFn<KV<String, Integer>> fetchSearchPageFn;
+	
+	private final Schema schema;
+	
+	FetchPatientHistory(FhirEtlOptions options, String resourceType, Schema schema) {
+		Preconditions.checkState(!options.getActivePeriod().isEmpty());
+		List<String> dateRange = FhirSearchUtil.getDateRange(options.getActivePeriod());
+		
+		int count = options.getBatchSize();
+		this.schema = schema;
+		
+		fetchSearchPageFn = new FetchSearchPageFn<KV<String, Integer>>(options, resourceType + "_history") {
+			
+			@ProcessElement
+			public void ProcessElement(@Element KV<String, Integer> patientIdCount, MultiOutputReceiver out) {
+				String patientId = patientIdCount.getKey();
+				log.info(String.format("Already fetched %d %s resources for patient %s", patientIdCount.getValue(),
+				    resourceType, patientId));
+				log.info(String.format("Fetching historical %s resources for patient  %s", resourceType, patientId));
+				Bundle bundle = this.fhirSearchUtil.searchByPatientAndLastDate(resourceType, patientId, dateRange.get(0),
+				    count);
+				processBundle(bundle, out);
+				String nextUrl = this.fhirSearchUtil.getNextUrl(bundle);
+				while (nextUrl != null) {
+					bundle = this.fhirSearchUtil.searchByUrl(nextUrl, count, SummaryEnum.DATA);
+					processBundle(bundle, out);
+					nextUrl = this.fhirSearchUtil.getNextUrl(bundle);
+				}
+			}
+		};
+	}
+	
+	@Override
+	public PCollectionTuple expand(PCollection<KV<String, Integer>> patientIdCounts) {
+		PCollectionTuple records = patientIdCounts.apply(ParDo.of(fetchSearchPageFn)
+		        .withOutputTags(fetchSearchPageFn.avroTag, TupleTagList.of(Lists.newArrayList(fetchSearchPageFn.jsonTag))));
+		records.get(fetchSearchPageFn.avroTag).setCoder(AvroCoder.of(GenericRecord.class, schema));
+		return records;
+	}
+	
+	public PCollection<GenericRecord> getAvroRecords(PCollectionTuple records) {
+		return fetchSearchPageFn.getAvroRecords(records);
+	}
+	
+	public PCollection<String> getJsonRecords(PCollectionTuple records) {
+		return fetchSearchPageFn.getJsonRecords(records);
+	}
+	
+}

--- a/batch/src/main/java/org/openmrs/analytics/FetchResources.java
+++ b/batch/src/main/java/org/openmrs/analytics/FetchResources.java
@@ -1,0 +1,133 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.openmrs.analytics;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import ca.uhn.fhir.rest.api.SummaryEnum;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Property;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This function object fetches all input segments from the FHIR source and converts each resource
+ * to JSON or Avro (or both). If a FHIR sink address is provided, those resources are passed to that
+ * FHIR sink too.
+ */
+// TODO: Add unit-tests for this class
+public class FetchResources extends PTransform<PCollection<SearchSegmentDescriptor>, PCollectionTuple> {
+	
+	private static final Logger log = LoggerFactory.getLogger(FetchResources.class);
+	
+	private static final Pattern PATIENT_REFERENCE = Pattern.compile(".*Patient/([^/]+)");
+	
+	final private Schema schema;
+	
+	final private FetchSearchPageFn<SearchSegmentDescriptor> fetchSearchPageFn;
+	
+	final private TupleTag<KV<String, Integer>> patientIdTag = new TupleTag<KV<String, Integer>>() {};
+	
+	FetchResources(FhirEtlOptions options, String stageIdentifier, Schema schema) {
+		this.schema = schema;
+		fetchSearchPageFn = new FetchSearchPageFn<SearchSegmentDescriptor>(options, stageIdentifier) {
+			
+			@ProcessElement
+			public void ProcessElement(@Element SearchSegmentDescriptor segment, MultiOutputReceiver out) {
+				String searchUrl = segment.searchUrl();
+				log.info(String.format("Fetching %d resources for statge %s; URL= %s", segment.count(), this.stageIdentifier,
+				    searchUrl.substring(0, Math.min(200, searchUrl.length()))));
+				long fetchStartTime = System.currentTimeMillis();
+				Bundle pageBundle = fhirSearchUtil.searchByUrl(searchUrl, segment.count(), SummaryEnum.DATA);
+				addFetchTime(System.currentTimeMillis() - fetchStartTime);
+				processBundle(pageBundle, out);
+				if (pageBundle != null && pageBundle.getEntry() != null) {
+					for (BundleEntryComponent entry : pageBundle.getEntry()) {
+						String patientId = getSubjectPatientIdOrNull(entry.getResource());
+						if (patientId != null) {
+							out.get(patientIdTag).output(KV.of(patientId, 1));
+						}
+					}
+				}
+			}
+		};
+		
+	}
+	
+	@VisibleForTesting
+	static String getSubjectPatientIdOrNull(Resource resource) {
+		String patinetId = null;
+		Property subject = resource.getNamedProperty("subject");
+		if (subject != null) {
+			List<Base> values = subject.getValues();
+			if (values.size() == 1) {
+				Reference reference = (Reference) values.get(0);
+				// TODO: Find a more generic way to check if this is a reference to a Patient. With the
+				// current OpenMRS setup, reference.getType() is null so we cannot rely on that.
+				String refStr = reference.getReference();
+				Matcher matcher = PATIENT_REFERENCE.matcher(refStr);
+				if (matcher.matches()) {
+					patinetId = matcher.group(1);
+				}
+				if (patinetId == null) {
+					log.warn(String.format("Ignoring subject of %s with id %s because it is not a Patient reference: %s",
+					    resource.getResourceType(), resource.getId(), refStr));
+				}
+			}
+			if (values.size() > 1) {
+				log.warn(String.format("Unexpected multiple values for subject of %s with id %s", resource.getResourceType(),
+				    resource.getId()));
+			}
+		}
+		return patinetId;
+	}
+	
+	@Override
+	public PCollectionTuple expand(PCollection<SearchSegmentDescriptor> segments) {
+		PCollectionTuple records = segments.apply(ParDo.of(fetchSearchPageFn).withOutputTags(fetchSearchPageFn.avroTag,
+		    TupleTagList.of(Lists.newArrayList(fetchSearchPageFn.jsonTag, patientIdTag))));
+		records.get(fetchSearchPageFn.avroTag).setCoder(AvroCoder.of(GenericRecord.class, schema));
+		return records;
+	}
+	
+	public PCollection<GenericRecord> getAvroRecords(PCollectionTuple records) {
+		return fetchSearchPageFn.getAvroRecords(records);
+	}
+	
+	public PCollection<String> getJsonRecords(PCollectionTuple records) {
+		return fetchSearchPageFn.getJsonRecords(records);
+	}
+	
+	public PCollection<KV<String, Integer>> getPatientIds(PCollectionTuple records) {
+		return records.get(patientIdTag);
+	}
+}

--- a/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
@@ -33,23 +33,22 @@ public interface FhirEtlOptions extends PipelineOptions {
 	
 	void setOpenmrsServerUrl(String value);
 	
+	// TODO merge this with `openmrsServerUrl` to `fhirBaseUrl`
 	@Description("OpenMRS server fhir endpoint")
 	@Default.String("/ws/fhir2/R4")
 	String getServerFhirEndpoint();
 	
 	void setServerFhirEndpoint(String value);
 	
-	@Description("Comma separated list of resource and search parameters to fetch; in its simplest "
-	        + "form this is a list of resources, e.g., `Patient,Encounter,Observation` but more "
-	        + "complex search paths are possible too, e.g., `Patient?name=Susan.`"
-	        + "Please note that complex search params doesn't work when JDBC mode is enabled.")
+	@Description("Comma separated list of resource to fetch, e.g., 'Patient,Encounter,Observation'.")
 	@Default.String("Patient,Encounter,Observation")
-	String getSearchList();
+	String getResourceList();
 	
-	void setSearchList(String value);
+	void setResourceList(String value);
 	
 	@Description("The number of resources to be fetched in one API call. "
-	        + "For the JDBC mode passing > 170 could result in HTTP 400 Bad Request")
+	        + "For the JDBC mode passing > 170 could result in HTTP 400 Bad Request. "
+	        + "Note by default the maximum bundle size for OpenMRS FHIR module is 100.")
 	@Default.Integer(100)
 	int getBatchSize();
 	
@@ -172,4 +171,18 @@ public interface FhirEtlOptions extends PipelineOptions {
 	int getSecondsToFlushFiles();
 	
 	void setSecondsToFlushFiles(int value);
+	
+	@Description("The active period with format: 'DATE1_DATE2' OR 'DATE1'. The first form declares "
+	        + "the first date-time (non-inclusive) and last date-time (inclusive); the second form declares "
+	        + "the active period to be from the given date-time (non-inclusive) until now. Resources outside "
+	        + "the active period are only fetched if they are associated with Patients in the active period. "
+	        + "All requested resources in the active period are fetched.\n"
+	        + "The format of DATE1 and DATE2 follows the dateTime format in the FHIR standard:\n"
+	        + "https://www.hl7.org/fhir/datatypes.html#dateTime\n"
+	        + "For example: --activePeriod=2020-11-10T00:00:00_2020-11-20\n"
+	        + "Default empty string disables this feature, i.e., all requested resources are fetched.")
+	@Default.String("")
+	String getActivePeriod();
+	
+	void setActivePeriod(String value);
 }

--- a/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
@@ -16,9 +16,20 @@ package org.openmrs.analytics;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.DateClientParam;
+import ca.uhn.fhir.rest.gclient.IQuery;
+import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.hl7.fhir.r4.model.Bundle;
@@ -29,13 +40,13 @@ public class FhirSearchUtil {
 	
 	private static final Logger log = LoggerFactory.getLogger(FhirSearchUtil.class);
 	
-	private OpenmrsUtil openmrsUtil;
+	private final OpenmrsUtil openmrsUtil;
 	
 	FhirSearchUtil(OpenmrsUtil openmrsUtil) {
 		this.openmrsUtil = openmrsUtil;
 	}
 	
-	Bundle searchByUrl(String searchUrl, int count, SummaryEnum summaryMode) {
+	public Bundle searchByUrl(String searchUrl, int count, SummaryEnum summaryMode) {
 		try {
 			IGenericClient client = openmrsUtil.getSourceClient();
 			Bundle result = client.search().byUrl(searchUrl).count(count).summaryMode(summaryMode).returnBundle(Bundle.class)
@@ -48,13 +59,15 @@ public class FhirSearchUtil {
 		return null;
 	}
 	
-	public String findBaseSearchUrl(Bundle searchBundle) {
-		String searchLink = null;
-		
-		if (searchBundle.getLink(Bundle.LINK_NEXT) != null) {
-			searchLink = searchBundle.getLink(Bundle.LINK_NEXT).getUrl();
+	public String getNextUrl(Bundle bundle) {
+		if (bundle.getLink(Bundle.LINK_NEXT) != null) {
+			return bundle.getLink(Bundle.LINK_NEXT).getUrl();
 		}
-		
+		return null;
+	}
+	
+	public String findBaseSearchUrl(Bundle searchBundle) {
+		String searchLink = getNextUrl(searchBundle);
 		if (searchLink == null) {
 			throw new IllegalArgumentException(String.format("No proper link information in bundle %s", searchBundle));
 		}
@@ -79,4 +92,133 @@ public class FhirSearchUtil {
 		}
 	}
 	
+	public String findSelfUrl(Bundle searchBundle) {
+		String selfLink = null;
+		
+		if (searchBundle.getLink(Bundle.LINK_SELF) != null) {
+			selfLink = searchBundle.getLink(Bundle.LINK_SELF).getUrl();
+		}
+		
+		if (selfLink == null) {
+			throw new IllegalArgumentException(String.format("No proper self link information in bundle %s", searchBundle));
+		}
+		return selfLink;
+	}
+	
+	private IQuery<Bundle> makeQueryForResource(String resourceType, int count) {
+		IGenericClient client = openmrsUtil.getSourceClient(true);
+		return client.search().forResource(resourceType).count(count).summaryMode(SummaryEnum.DATA)
+		        .returnBundle(Bundle.class);
+	}
+	
+	static List<String> getDateRange(String activePeriod) {
+		if (activePeriod.isEmpty()) {
+			return Lists.newArrayList();
+		}
+		String[] dateRange = activePeriod.split("_");
+		if (dateRange.length != 1 && dateRange.length != 2) {
+			throw new IllegalArgumentException("Invalid activePeriod '" + activePeriod
+			        + "'; the format should be: DATE1_DATE2 or DATE1; see the flag description.");
+		}
+		return Lists.newArrayList(dateRange);
+	}
+	
+	private IQuery<Bundle> makeQueryWithDate(String resourceType, FhirEtlOptions options) {
+		IQuery<Bundle> searchQuery = makeQueryForResource(resourceType, options.getBatchSize());
+		if (!options.getActivePeriod().isEmpty()) {
+			List<String> dateRange = getDateRange(options.getActivePeriod());
+			searchQuery = searchQuery.where(new DateClientParam("date").after().second(dateRange.get(0)));
+			if (dateRange.size() > 1) {
+				searchQuery = searchQuery.where(new DateClientParam("date").beforeOrEquals().second(dateRange.get(1)));
+				log.info(String.format("Fetching all %s resources after %s and beforeOrEqual %s", resourceType,
+				    dateRange.get(0), dateRange.get(1)));
+			} else {
+				log.info(String.format("Fetching all %s resources after %s", resourceType, dateRange.get(0)));
+			}
+		}
+		return searchQuery;
+	}
+	
+	Map<String, List<SearchSegmentDescriptor>> createSegments(FhirEtlOptions options) {
+		if (options.getBatchSize() > 100) {
+			// TODO: Probe this value from the server and set the maximum automatically.
+			log.warn("NOTE batchSize flag is higher than 100; make sure that `fhir2.paging.maximum` "
+			        + "is set accordingly on the OpenMRS server.");
+		}
+		Map<String, List<SearchSegmentDescriptor>> segmentMap = new HashMap<>();
+		
+		boolean anyResourceWithDate = false;
+		for (String resourceType : options.getResourceList().split(",")) {
+			List<SearchSegmentDescriptor> segments = new ArrayList<>();
+			segmentMap.put(resourceType, segments);
+			IQuery<Bundle> searchQuery = makeQueryWithDate(resourceType, options);
+			log.info(String.format("Fetching first batch of %s", resourceType));
+			Bundle searchBundle = null;
+			try {
+				searchBundle = searchQuery.execute();
+				anyResourceWithDate = true;
+			}
+			catch (InvalidRequestException e) {
+				log.warn(String.format("While searching for resource %s with date, caught exception %s", resourceType,
+				    e.toString()));
+				log.info("Trying without date for resource " + resourceType);
+				searchBundle = makeQueryForResource(resourceType, options.getBatchSize()).execute();
+			}
+			if (searchBundle == null) {
+				log.error("Failed searching for resource " + resourceType);
+				throw new IllegalStateException("Failed searching for resource " + resourceType);
+			}
+			int total = searchBundle.getTotal();
+			log.info(String.format("Number of resources for %s search is %d", resourceType, total));
+			if (searchBundle.getEntry().size() >= total) {
+				// No parallelism is needed in this case; we get all resources in one bundle.
+				segments.add(SearchSegmentDescriptor.create(findSelfUrl(searchBundle), options.getBatchSize()));
+			} else {
+				String baseUrl = findBaseSearchUrl(searchBundle) + "&_getpagesoffset=";
+				for (int offset = 0; offset < total; offset += options.getBatchSize()) {
+					String pageSearchUrl = baseUrl + offset;
+					segments.add(SearchSegmentDescriptor.create(pageSearchUrl, options.getBatchSize()));
+				}
+				log.info(String.format("Total number of segments for resource %s is %d", resourceType, segments.size()));
+			}
+		}
+		if (!options.getActivePeriod().isEmpty() && !anyResourceWithDate) {
+			throw new IllegalArgumentException(
+			        String.format("None of the provided %s resources supported the 'date' options in the active period %s",
+			            options.getResourceList(), options.getActivePeriod()));
+		}
+		return segmentMap;
+	}
+	
+	public Set<String> findPatientAssociatedResources(Set<String> resourceTypes) {
+		// Note this can also be done by fetching server's `metadata` and parsing the CapabilityStatement.
+		Set<String> patientAssociatedResources = Sets.newHashSet();
+		IGenericClient client = openmrsUtil.getSourceClient(true);
+		for (String resourceType : resourceTypes) {
+			IQuery<Bundle> query = client.search().forResource(resourceType).count(0).summaryMode(SummaryEnum.DATA)
+			        .returnBundle(Bundle.class);
+			// Try with a test ID and a random date to see whether the server can handle the search query.
+			query = query.where(new ReferenceClientParam("patient").hasId("THIS_IS_FOR_TEST"))
+			        .where(new DateClientParam("date").after().second("2021-01-01T00:00:00"));
+			try {
+				query.execute();
+				patientAssociatedResources.add(resourceType);
+			}
+			catch (InvalidRequestException e) {
+				log.warn(String.format(
+				    "Server does not have 'patient' search param for resource %s; will not fetch historical %s resources.",
+				    resourceType, resourceType));
+			}
+		}
+		return patientAssociatedResources;
+	}
+	
+	Bundle searchByPatientAndLastDate(String resourceType, String patientId, String lastDate, int count) {
+		IGenericClient client = openmrsUtil.getSourceClient(true);
+		IQuery<Bundle> query = client.search().forResource(resourceType).count(count).summaryMode(SummaryEnum.DATA)
+		        .returnBundle(Bundle.class);
+		query = query.where(new ReferenceClientParam("patient").hasId(patientId))
+		        .where(new DateClientParam("date").beforeOrEquals().second(lastDate));
+		return query.execute();
+	}
 }

--- a/batch/src/test/java/org/openmrs/analytics/FetchResourcesTest.java
+++ b/batch/src/test/java/org/openmrs/analytics/FetchResourcesTest.java
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.openmrs.analytics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.google.common.io.Resources;
+import org.hl7.fhir.r4.model.Observation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FetchResourcesTest {
+	
+	private FetchResources fetchResources;
+	
+	private FhirContext fhirContext;
+	
+	private Observation observation;
+	
+	@Before
+	public void setup() throws IOException {
+		URL url = Resources.getResource("observation.json");
+		String obsStr = Resources.toString(url, StandardCharsets.UTF_8);
+		this.fhirContext = FhirContext.forR4();
+		IParser parser = fhirContext.newJsonParser();
+		observation = parser.parseResource(Observation.class, obsStr);
+		// TODO BEFORE SUBMUT: remove it not needed!
+		//  fetchResources = new FetchResources(null, "Observation", null);
+	}
+	
+	@Test
+	public void testGetPatientId() {
+		String expectedId = "471be3bc-08c7-4d78-a4ab-1b3d044dae67";
+		String patientId = FetchResources.getSubjectPatientIdOrNull(observation);
+		assertThat(patientId, notNullValue());
+		assertThat(patientId, equalTo(expectedId));
+	}
+	
+}

--- a/batch/src/test/resources/observation.json
+++ b/batch/src/test/resources/observation.json
@@ -1,0 +1,32 @@
+{
+  "resourceType": "Observation",
+  "id": "0adb6cfb-0ae3-42df-9d39-fc68ec4334cd",
+  "meta": {
+    "tag": [
+      {
+        "system": "http://hl7.org/fhir/v3/ObservationValue",
+        "code": "SUBSETTED",
+        "display": "Resource encoded in summary mode"
+      }
+    ]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "code": "162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "display": "Text of encounter note"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/471be3bc-08c7-4d78-a4ab-1b3d044dae67",
+    "display": "Bashir Sadjad (OpenMRS ID: 10000X)"
+  },
+  "context": {
+    "reference": "Encounter/2df7151b-fdde-4d1b-8dfa-aeaae4bb0430"
+  },
+  "effectiveDateTime": "2020-09-22T13:54:41-04:00",
+  "issued": "2020-09-22T13:54:41.000-04:00",
+  "valueString": "Adding a test diagnosis"
+}

--- a/common/src/main/java/org/openmrs/analytics/OpenmrsUtil.java
+++ b/common/src/main/java/org/openmrs/analytics/OpenmrsUtil.java
@@ -18,6 +18,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
@@ -65,11 +66,22 @@ public class OpenmrsUtil {
 	}
 	
 	public IGenericClient getSourceClient() {
+		return getSourceClient(false);
+	}
+	
+	public IGenericClient getSourceClient(boolean enableRequestLogging) {
 		IClientInterceptor authInterceptor = new BasicAuthInterceptor(this.sourceUser, this.sourcePw);
 		fhirContext.getRestfulClientFactory().setSocketTimeout(200 * 1000);
 		
 		IGenericClient client = fhirContext.getRestfulClientFactory().newGenericClient(this.fhirUrl);
 		client.registerInterceptor(authInterceptor);
+		
+		if (enableRequestLogging) {
+			LoggingInterceptor loggingInterceptor = new LoggingInterceptor();
+			loggingInterceptor.setLogger(log);
+			loggingInterceptor.setLogRequestSummary(true);
+			client.registerInterceptor(loggingInterceptor);
+		}
 		
 		return client;
 	}

--- a/doc/openhim.md
+++ b/doc/openhim.md
@@ -71,7 +71,7 @@ for batch
 
 ```
 mvn compile exec:java -pl batch \
-    "-Dexec.args=--openmrsServerUrl=http://localhost:8099/openmrs  --searchList=Patient \
+    "-Dexec.args=--openmrsServerUrl=http://localhost:8099/openmrs  --resourceList=Patient \
     --batchSize=20 --targetParallelism=20  \
     --fhirSinkPath=http://localhost:5001/fhir \
     --sinkUserName=hapi --sinkPassword=Admin123 \

--- a/e2e-tests/batch-mode-tests.sh
+++ b/e2e-tests/batch-mode-tests.sh
@@ -73,7 +73,7 @@ function setup() {
 function test_parquet_sink() {
   local command=(mvn exec:java -pl batch "-Dexec.args=--openmrsServerUrl=http://localhost:8099/openmrs \
         --openmrsUserName=admin --openmrsPassword=Admin123 \
-        --searchList=Patient,Encounter,Observation --batchSize=20 $1")
+        --resourceList=Patient,Encounter,Observation --batchSize=20 $1")
   local test_dir=$2
   local mode=$3
   print_message "PARQUET FILES WILL BE WRITTEN INTO ${test_dir} DIRECTORY"
@@ -134,7 +134,7 @@ function test_parquet_sink() {
 #   the mode to test: FHIR Search vs JDBC
 #######################################
 function test_fhir_sink() {
-  local command=(mvn exec:java -pl batch "-Dexec.args=--searchList=Patient --batchSize=20  \
+  local command=(mvn exec:java -pl batch "-Dexec.args=--resourceList=Patient --batchSize=20  \
   --fhirSinkPath=http://localhost:8098/fhir  --sinkUserName=hapi --sinkPassword=hapi $1")
   local test_dir=$2
   local mode=$3

--- a/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/streaming-binlog/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -134,6 +134,7 @@ public class DebeziumListener extends RouteBuilder {
 		public DebeziumArgs() {
 		};
 		
+		// TODO merge this with `openmrsServerUrl` flag to `fhirBaseUrl`.
 		@Parameter(names = { "--openmrsfhirBaseEndpoint" }, description = "Fhir base endpoint")
 		public String openmrsfhirBaseEndpoint = "/ws/fhir2/R4";
 		


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->
This implements issue #128 by adding an `--activePeriod` feature. For details, see [this comment](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/issues/128#issuecomment-806262942).

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:
Ran:
```
$ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar org.openmrs.analytics.FhirEtl \
  --openmrsServerUrl=http://localhost:8099/openmrs --resourceList=Patient,Encounter,Observation \
  --targetParallelism=10 --numFileShards=3 --secondsToFlushFiles=1200 \
  --outputParquetPath=[PATH] --activePeriod=2020-11-10T00:00:00
```
Then compared the list of `patientId`s for whom the historical resources were fetched to `uuid`s of the following MySQL query:
```
SELECT person.uuid, patient_id, COUNT(0) AS num_encounters
FROM person, encounter
WHERE person.person_id=encounter.patient_id AND encounter.voided=0
  AND encounter_datetime >= "2020-11-10"
GROUP BY patient_id ORDER BY patient_id
```

Also ran this to check the two dates version of `--activePeriod`:
```
$ java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar org.openmrs.analytics.FhirEtl \
  --openmrsServerUrl=http://localhost:8099/openmrs --resourceList=Patient,Encounter,Observation \
  --targetParallelism=10 --numFileShards=3 --secondsToFlushFiles=1200 \
  --outputParquetPath=[PATH] --activePeriod=2020-11-10T00:00:00_2020-11-20
```

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note, when in conflict, OpenMRS style guide overrules.

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests) [More unit-tests as TODO.]

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

