### PR TITLE
Added a null check in getNextUrl

### DIFF
--- a/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
+++ b/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.rest.gclient.DateClientParam;
 import ca.uhn.fhir.rest.gclient.IQuery;
 import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.http.NameValuePair;
@@ -60,13 +61,14 @@ public class FhirSearchUtil {
 	}
 	
 	public String getNextUrl(Bundle bundle) {
-		if (bundle.getLink(Bundle.LINK_NEXT) != null) {
+		if (bundle != null && bundle.getLink(Bundle.LINK_NEXT) != null) {
 			return bundle.getLink(Bundle.LINK_NEXT).getUrl();
 		}
 		return null;
 	}
 	
-	public String findBaseSearchUrl(Bundle searchBundle) {
+	@VisibleForTesting
+	String findBaseSearchUrl(Bundle searchBundle) {
 		String searchLink = getNextUrl(searchBundle);
 		if (searchLink == null) {
 			throw new IllegalArgumentException(String.format("No proper link information in bundle %s", searchBundle));

--- a/batch/src/test/java/org/openmrs/analytics/FhirSearchUtilTest.java
+++ b/batch/src/test/java/org/openmrs/analytics/FhirSearchUtilTest.java
@@ -15,6 +15,7 @@ package org.openmrs.analytics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
@@ -46,8 +47,6 @@ public class FhirSearchUtilTest {
 	
 	private static final String SEARCH_URL = "Patient?given=TEST";
 	
-	private String bundleStr;
-	
 	@Mock
 	private OpenmrsUtil openmrsUtil;
 	
@@ -69,7 +68,7 @@ public class FhirSearchUtilTest {
 	@Before
 	public void setup() throws IOException {
 		URL url = Resources.getResource("bundle.json");
-		bundleStr = Resources.toString(url, StandardCharsets.UTF_8);
+		String bundleStr = Resources.toString(url, StandardCharsets.UTF_8);
 		this.fhirContext = FhirContext.forR4();
 		IParser parser = fhirContext.newJsonParser();
 		bundle = parser.parseResource(Bundle.class, bundleStr);
@@ -94,5 +93,19 @@ public class FhirSearchUtilTest {
 	public void testSearchForResource() {
 		Bundle actualBundle = fhirSearchUtil.searchByUrl(SEARCH_URL, 10, SummaryEnum.DATA);
 		assertThat(actualBundle.equalsDeep(bundle), equalTo(true));
+	}
+	
+	@Test
+	public void testGetNextUrlNull() {
+		String bundleStr = "{ \"resourceType\": \"Bundle\",\n" + "    \"id\": \"3beab86b-ca1a-427b-8c5f-07635010c1d5\",\n"
+		        + "    \"meta\": { \"lastUpdated\": \"2021-04-22T05:08:33.750+03:00\" },\n"
+		        + "    \"type\": \"searchset\",\n" + "    \"total\": 0,\n" + "    \"link\": [\n" + "        {\n"
+		        + "            \"relation\": \"self\",\n"
+		        + "            \"url\": \"http://domain.com/openmrs/ws/fhir2/R4/Encounter?_count=100&_summary=data\"\n"
+		        + "        }\n" + "    ]\n" + "}";
+		IParser parser = fhirContext.newJsonParser();
+		bundle = parser.parseResource(Bundle.class, bundleStr);
+		String nextUrl = fhirSearchUtil.getNextUrl(bundle);
+		assertThat(nextUrl, nullValue());
 	}
 }


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->
This adds an extra null-check in `getNextUrl`. Although it is not clear how this condition can be triggered but some test runs against real data have shown this behavior, so better to prevent crashing the pipeline.

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:
Sample run:
```
java -cp batch/target/fhir-batch-etl-bundled-0.1.0-SNAPSHOT.jar org.openmrs.analytics.FhirEtl \
  --openmrsServerUrl=http://localhost:8099/openmrs --resourceList=Encounter,Observation \
  --targetParallelism=10 --numFileShards=3 --secondsToFlushFiles=1200 \
  --outputParquetPath=[PATH] --jdbcUrl=jdbc:mysql://localhost:3306/openmrs \
  --jdbcMaxPoolSize=100 --jdbcModeEnabled --activePeriod=2020-11-09T10:00:00_2020-11-11
```

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note, when in conflict, OpenMRS style guide overrules.

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

